### PR TITLE
Add Airflow orchestration for raw pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,6 @@ AIRFLOW_ADMIN_PASSWORD=change_me
 AIRFLOW_ADMIN_FIRSTNAME=First
 AIRFLOW_ADMIN_LASTNAME=Last
 AIRFLOW_ADMIN_EMAIL=admin@example.com
-AIRFLOW_CONN_MOBILITY_POSTGRES=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${MOBILITY_DB}
 AIRFLOW__WEBSERVER__SECRET_KEY=change_me_generate_a_long_random_string_here_min_32_chars
 AIRFLOW__CORE__FERNET_KEY=change_me_generate_fernet_key
 

--- a/airflow/dags/mobility_raw_pipeline.py
+++ b/airflow/dags/mobility_raw_pipeline.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models.param import Param
+from airflow.operators.bash import BashOperator
+
+
+PROJECT_DIR = "/opt/airflow"
+DATA_DIR = f"{PROJECT_DIR}/data"
+DBT_PROJECT_DIR = f"{PROJECT_DIR}/dbt/berlin_mobility"
+DBT_BIN = "/opt/airflow/dbt_venv/bin/dbt"
+
+
+with DAG(
+    dag_id="mobility_raw_pipeline",
+    start_date=datetime(2026, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["mobility", "raw", "dbt"],
+    params={
+        "bike_start_year": Param(2025, type="integer"),
+        "bike_end_year": Param(2025, type="integer"),
+        "weather_latitude": Param(52.52, type="number"),
+        "weather_longitude": Param(13.405, type="number"),
+        "weather_start_date": Param("2025-01-01", type="string"),
+        "weather_end_date": Param("2025-12-31", type="string"),
+    },
+) as dag:
+    extract_bike_data = BashOperator(
+        task_id="extract_bike_data",
+        bash_command=(
+            "python /opt/airflow/scripts/bike_data_extraction.py "
+            "--start-year {{ params.bike_start_year }} "
+            "--end-year {{ params.bike_end_year }} "
+            f"--output-counts {DATA_DIR}/mobility_long.csv "
+            f"--output-metadata {DATA_DIR}/mobility_metadata.csv"
+        ),
+    )
+
+    extract_weather_data = BashOperator(
+        task_id="extract_weather_data",
+        bash_command=(
+            "python /opt/airflow/scripts/openmeteo_weather_export.py "
+            "--latitude {{ params.weather_latitude }} "
+            "--longitude {{ params.weather_longitude }} "
+            "--start-date {{ params.weather_start_date }} "
+            "--end-date {{ params.weather_end_date }} "
+            f"--output {DATA_DIR}/weather_data.csv "
+            f"--cache-path {DATA_DIR}/.openmeteo_cache"
+        ),
+    )
+
+    load_raw_tables = BashOperator(
+        task_id="load_raw_tables",
+        bash_command=(
+            "python /opt/airflow/scripts/load_csv_to_postgres.py "
+            f"--counts {DATA_DIR}/mobility_long.csv "
+            f"--metadata {DATA_DIR}/mobility_metadata.csv "
+            f"--weather {DATA_DIR}/weather_data.csv"
+        ),
+    )
+
+    validate_raw_tables = BashOperator(
+        task_id="validate_raw_tables",
+        bash_command="python /opt/airflow/scripts/validate_raw_data.py",
+    )
+
+    dbt_deps = BashOperator(
+        task_id="dbt_deps",
+        bash_command=f"{DBT_BIN} deps --project-dir {DBT_PROJECT_DIR}",
+    )
+
+    dbt_run = BashOperator(
+        task_id="dbt_run",
+        bash_command=(
+            f"{DBT_BIN} run --project-dir {DBT_PROJECT_DIR} "
+            f"--profiles-dir {DBT_PROJECT_DIR}"
+        ),
+    )
+
+    dbt_test = BashOperator(
+        task_id="dbt_test",
+        bash_command=(
+            f"{DBT_BIN} test --project-dir {DBT_PROJECT_DIR} "
+            f"--profiles-dir {DBT_PROJECT_DIR}"
+        ),
+    )
+
+    [extract_bike_data, extract_weather_data] >> load_raw_tables
+    load_raw_tables >> validate_raw_tables >> dbt_deps >> dbt_run >> dbt_test

--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,0 +1,12 @@
+FROM apache/airflow:2.8.1-python3.11
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN pip install --no-cache-dir \
+    -r /tmp/requirements.txt \
+    apache-airflow-providers-postgres
+
+RUN python -m venv /opt/airflow/dbt_venv \
+    && PIP_USER=false /opt/airflow/dbt_venv/bin/pip install --no-cache-dir \
+        dbt-core==1.10.22 \
+        dbt-postgres==1.9.1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,21 +1,31 @@
 x-airflow-common: &airflow-common
-  image: apache/airflow:2.8.1
+  build:
+    context: ..
+    dockerfile: docker/airflow/Dockerfile
+  image: berlin-mobility-airflow:latest
   environment:
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres/${AIRFLOW_DB}
     AIRFLOW__CORE__LOAD_EXAMPLES: "false"
-    AIRFLOW_CONN_MOBILITY_POSTGRES: ${AIRFLOW_CONN_MOBILITY_POSTGRES}
+    AIRFLOW_CONN_MOBILITY_POSTGRES: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${MOBILITY_DB}
     AIRFLOW__WEBSERVER__SECRET_KEY: ${AIRFLOW__WEBSERVER__SECRET_KEY}
     AIRFLOW__CORE__FERNET_KEY: ${AIRFLOW__CORE__FERNET_KEY}
+    POSTGRES_HOST: postgres
+    POSTGRES_PORT: 5432
+    POSTGRES_USER: ${POSTGRES_USER}
+    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    MOBILITY_DB: ${MOBILITY_DB}
+    MOBILITY_DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${MOBILITY_DB}
   volumes:
     - ../airflow/dags:/opt/airflow/dags
+    - ../scripts:/opt/airflow/scripts
+    - ../data:/opt/airflow/data
+    - ../dbt:/opt/airflow/dbt
   depends_on:
     postgres:
       condition: service_healthy
   networks:
     - mobility_net
-
-
 
 services:
   postgres:
@@ -88,7 +98,7 @@ services:
     image: python:3.11-slim
     container_name: mobility_metabase_seed
     depends_on:
-    - metabase
+      - metabase
     environment:
       MB_SETUP_TOKEN: ${MB_SETUP_TOKEN}
       POSTGRES_USER: ${POSTGRES_USER}

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -69,6 +69,12 @@ If you already created the Postgres volume before these databases existed, recre
 
 ### 3️⃣ Start All Services
 
+Build the local Airflow image and start all services:
+
+    docker compose --env-file .env -f docker/docker-compose.yml up -d --build
+
+For subsequent starts without rebuilding:
+
     docker compose --env-file .env -f docker/docker-compose.yml up -d
 
 Verify running containers:
@@ -155,6 +161,23 @@ Run dbt tests:
     uv run dbt test \
       --project-dir dbt/berlin_mobility \
       --profiles-dir dbt/berlin_mobility
+
+---
+
+### 8️⃣ Run the Airflow Pipeline
+
+The DAG `mobility_raw_pipeline` orchestrates the local raw pipeline:
+
+- extract bike count CSVs
+- extract weather CSV
+- load raw PostgreSQL tables
+- validate raw tables
+- run dbt staging models
+- run dbt tests
+
+It is manually triggered by design. Start the stack, open Airflow, and trigger `mobility_raw_pipeline` from the UI.
+
+Default DAG parameters extract 2025 bike and weather data for a representative Berlin coordinate. Override the DAG params in the Airflow trigger dialog if needed.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,5 +19,6 @@ airflow = [
     "apache-airflow-providers-postgres",
 ]
 dbt = [
-    "dbt-postgres",
+    "dbt-core==1.10.22",
+    "dbt-postgres==1.9.1",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -334,8 +334,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apache-airflow" },
     { name = "more-itertools" },
-    { name = "sqlparse", version = "0.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "sqlparse", version = "0.5.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "sqlparse" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/ea/f481fdb03667feeede8495835d643e5896d0e39283d70f7b94a5104abe14/apache_airflow_providers_common_sql-1.20.0.tar.gz", hash = "sha256:2bc7c4b85a3b37ab9d18da7024203e1521574ff0a7bda3efba232170ab1b7d5e", size = 35477, upload-time = "2024-11-18T08:57:44.824Z" }
 wheels = [
@@ -522,8 +521,8 @@ airflow = [
     { name = "apache-airflow-providers-postgres" },
 ]
 dbt = [
-    { name = "dbt-postgres", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "dbt-postgres", version = "1.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "dbt-core" },
+    { name = "dbt-postgres" },
 ]
 
 [package.metadata]
@@ -541,7 +540,10 @@ airflow = [
     { name = "apache-airflow", specifier = "==2.8.1" },
     { name = "apache-airflow-providers-postgres" },
 ]
-dbt = [{ name = "dbt-postgres" }]
+dbt = [
+    { name = "dbt-core", specifier = "==1.10.22" },
+    { name = "dbt-postgres", specifier = "==1.9.1" },
+]
 
 [[package]]
 name = "blinker"
@@ -1062,77 +1064,41 @@ wheels = [
 name = "dbt-core"
 version = "1.10.22"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version > '3.9' and python_full_version < '3.10'",
-    "python_full_version <= '3.9'",
-]
 dependencies = [
-    { name = "agate", marker = "python_full_version < '3.10'" },
+    { name = "agate" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "daff", marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "daff" },
     { name = "dbt-adapters", version = "1.17.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-adapters", version = "1.24.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "dbt-common", version = "1.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "dbt-extractor", marker = "python_full_version < '3.10'" },
-    { name = "dbt-protos", marker = "python_full_version < '3.10'" },
-    { name = "dbt-semantic-interfaces", marker = "python_full_version < '3.10'" },
-    { name = "jinja2", marker = "python_full_version < '3.10'" },
+    { name = "dbt-common", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "dbt-extractor" },
+    { name = "dbt-protos" },
+    { name = "dbt-semantic-interfaces" },
+    { name = "jinja2" },
     { name = "jsonschema", version = "4.25.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version < '3.10'" },
+    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "mashumaro", extra = ["msgpack"] },
     { name = "networkx", version = "3.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "packaging", version = "24.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pathspec", marker = "python_full_version < '3.10'" },
-    { name = "protobuf", marker = "python_full_version < '3.10'" },
-    { name = "pydantic", marker = "python_full_version < '3.10'" },
-    { name = "pytz", marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
+    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pathspec" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "pyyaml" },
     { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "snowplow-tracker", marker = "python_full_version < '3.10'" },
-    { name = "sqlparse", version = "0.5.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "snowplow-tracker" },
+    { name = "sqlparse" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7b/f0/6891b867c772416dadc287d852bb58e5a937b1f48008a56eb867d19bedc9/dbt_core-1.10.22.tar.gz", hash = "sha256:78dcda2ec712a356f1b7d9ba82978def56d26bfe5bcaa54855107a9dc55c284f", size = 900881, upload-time = "2026-05-20T10:53:06.034Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/97/7d640a719ca22c96e809b521b95f3ddeb78cbd76d64a95eab90632c35ec0/dbt_core-1.10.22-py3-none-any.whl", hash = "sha256:c1bc28223419a205c15143282c104586b07efa6326c83268bee5f2c36d2d1ab4", size = 987258, upload-time = "2026-05-20T10:53:04.169Z" },
-]
-
-[[package]]
-name = "dbt-core"
-version = "1.11.11"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.10.*'",
-]
-dependencies = [
-    { name = "agate", marker = "python_full_version >= '3.10'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "daff", marker = "python_full_version >= '3.10'" },
-    { name = "dbt-adapters", version = "1.24.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "dbt-common", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "dbt-extractor", marker = "python_full_version >= '3.10'" },
-    { name = "dbt-protos", marker = "python_full_version >= '3.10'" },
-    { name = "dbt-semantic-interfaces", marker = "python_full_version >= '3.10'" },
-    { name = "jinja2", marker = "python_full_version >= '3.10'" },
-    { name = "jsonschema", version = "4.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "mashumaro", extra = ["msgpack"], marker = "python_full_version >= '3.10'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.10.*'" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging", version = "26.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pathspec", marker = "python_full_version >= '3.10'" },
-    { name = "protobuf", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "pytz", marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "requests", version = "2.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "snowplow-tracker", marker = "python_full_version >= '3.10'" },
-    { name = "sqlparse", version = "0.5.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/af8f4ab1e3e979b5677e876444f3a9c1b1021c2d4e77143e80f421bdc1f7/dbt_core-1.11.11.tar.gz", hash = "sha256:e53cfccc8c9c13a082e518bf80cf3bb33c2f1fdc3cab48ec822ef93737eccb81", size = 973079, upload-time = "2026-05-20T11:10:01.8Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/d2/9e1eb5d3c8f375d4e5523b9123b2ae25ea21d85abb044db2eff2e3ee9c1d/dbt_core-1.11.11-py3-none-any.whl", hash = "sha256:7f9e11f3f5400e20f40f544440800ace23fa0755086f87b08e9446181f8720e1", size = 1061938, upload-time = "2026-05-20T11:09:59.856Z" },
 ]
 
 [[package]]
@@ -1162,42 +1128,18 @@ wheels = [
 name = "dbt-postgres"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version > '3.9' and python_full_version < '3.10'",
-    "python_full_version <= '3.9'",
-]
 dependencies = [
-    { name = "agate", marker = "python_full_version < '3.10'" },
+    { name = "agate" },
     { name = "dbt-adapters", version = "1.17.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "dbt-adapters", version = "1.24.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "dbt-common", version = "1.34.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "dbt-core", version = "1.10.22", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "psycopg2-binary", marker = "python_full_version < '3.10'" },
+    { name = "dbt-common", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "dbt-core" },
+    { name = "psycopg2-binary" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0a/e3/cfd22fc9c49ef9dfb014693a4909c79a78748a5160f3279f1765f3a41587/dbt_postgres-1.9.1.tar.gz", hash = "sha256:cf78b06c190f6fea5e8c182f3376b1ba7cd8eb0368d7c75bdac9bf8cfcd71e31", size = 159308, upload-time = "2025-09-05T18:23:38.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/c7/7eb30411f81fd299410e7a4cebc73a60b8320179d032f2efe4bd378d7bae/dbt_postgres-1.9.1-py3-none-any.whl", hash = "sha256:114890c53b8dff20284cf432d8130f2bbec86ce156b3a16ce6defa0b68c68d7f", size = 35003, upload-time = "2025-09-05T18:23:36.811Z" },
-]
-
-[[package]]
-name = "dbt-postgres"
-version = "1.10.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.10.*'",
-]
-dependencies = [
-    { name = "agate", marker = "python_full_version >= '3.10'" },
-    { name = "dbt-adapters", version = "1.24.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "dbt-common", version = "1.38.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "dbt-core", version = "1.11.11", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "psycopg2-binary", marker = "python_full_version >= '3.10'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/f2/6d101b917c9f4a6c09a15cc239dc360be5b1115e27d5bdac9c6c3bead5f1/dbt_postgres-1.10.0.tar.gz", hash = "sha256:74dc7e8b531ab785bca9d44f3d1ee9b38c4cbac967eafe7373242ed181eb0fa2", size = 160230, upload-time = "2025-12-22T20:02:44.149Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/70/4f8ab84353844e5c5b2961d18f8c3d171b539c2c0425f855c550d766c960/dbt_postgres-1.10.0-py3-none-any.whl", hash = "sha256:9bc9d07342edbc86c16e20b2ab02c211c30c09b03736f925d612d963cbbe4f94", size = 35520, upload-time = "2025-12-22T20:02:42.792Z" },
 ]
 
 [[package]]
@@ -4393,28 +4335,9 @@ wheels = [
 name = "sqlparse"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version > '3.9' and python_full_version < '3.10'",
-    "python_full_version <= '3.9'",
-]
 sdist = { url = "https://files.pythonhosted.org/packages/18/67/701f86b28d63b2086de47c942eccf8ca2208b3be69715a1119a4e384415a/sqlparse-0.5.4.tar.gz", hash = "sha256:4396a7d3cf1cd679c1be976cf3dc6e0a51d0111e87787e7a8d780e7d5a998f9e", size = 120112, upload-time = "2025-11-28T07:10:18.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/70/001ee337f7aa888fb2e3f5fd7592a6afc5283adb1ed44ce8df5764070f22/sqlparse-0.5.4-py3-none-any.whl", hash = "sha256:99a9f0314977b76d776a0fcb8554de91b9bb8a18560631d6bc48721d07023dcb", size = 45933, upload-time = "2025-11-28T07:10:19.73Z" },
-]
-
-[[package]]
-name = "sqlparse"
-version = "0.5.5"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "python_full_version >= '3.11' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.10.*'",
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a custom Airflow image with project Python dependencies and isolated dbt CLI
- add a manual mobility_raw_pipeline DAG for extract, load, validate, dbt run, and dbt test
- document the local build/start flow and Airflow trigger path

## Verification
- git diff --check
- docker compose --env-file .env -f docker/docker-compose.yml config
- docker compose --env-file .env -f docker/docker-compose.yml build airflow-init
- docker compose --env-file .env -f docker/docker-compose.yml run --rm --entrypoint airflow airflow-init dags list
- docker compose --env-file .env -f docker/docker-compose.yml run --rm --entrypoint /opt/airflow/dbt_venv/bin/dbt airflow-init --version
- docker compose --env-file .env -f docker/docker-compose.yml run --rm --entrypoint /opt/airflow/dbt_venv/bin/dbt airflow-init deps --project-dir /opt/airflow/dbt/berlin_mobility