### PR TITLE
Add mobility weather fact mart

### DIFF
--- a/dbt/berlin_mobility/dbt_project.yml
+++ b/dbt/berlin_mobility/dbt_project.yml
@@ -11,4 +11,5 @@ models:
   berlin_mobility:
     staging:
       +materialized: view
-
+    marts:
+      +materialized: view

--- a/dbt/berlin_mobility/models/marts/fact_mobility_weather.sql
+++ b/dbt/berlin_mobility/models/marts/fact_mobility_weather.sql
@@ -1,0 +1,65 @@
+with mobility_counts as (
+    select
+        observed_at,
+        station_id,
+        bike_count
+    from {{ ref('stg_mobility_counts') }}
+),
+
+station_metadata as (
+    select
+        station_id,
+        description as station_description,
+        latitude as station_latitude,
+        longitude as station_longitude,
+        installed as station_installed_date,
+        direction as station_direction
+    from {{ ref('stg_station_metadata') }}
+),
+
+weather_hourly as (
+    select
+        weather_at,
+        temperature_2m,
+        apparent_temperature,
+        precipitation,
+        weather_code,
+        cloud_cover,
+        wind_speed_10m,
+        relative_humidity_2m,
+        wind_gusts_10m,
+        weather_description
+    from {{ ref('stg_weather_hourly') }}
+)
+
+select
+    mobility_counts.observed_at,
+    timezone('Europe/Berlin', mobility_counts.observed_at) as observed_local_at,
+    mobility_counts.station_id,
+    mobility_counts.bike_count,
+
+    cast(timezone('Europe/Berlin', mobility_counts.observed_at) as date) as observed_date,
+    extract(hour from timezone('Europe/Berlin', mobility_counts.observed_at))::integer as observed_hour,
+    extract(isodow from timezone('Europe/Berlin', mobility_counts.observed_at))::integer as observed_isodow,
+    extract(isodow from timezone('Europe/Berlin', mobility_counts.observed_at))::integer in (6, 7) as is_weekend,
+
+    station_metadata.station_description,
+    station_metadata.station_latitude,
+    station_metadata.station_longitude,
+    station_metadata.station_installed_date,
+    station_metadata.station_direction,
+
+    weather_hourly.temperature_2m,
+    weather_hourly.apparent_temperature,
+    weather_hourly.precipitation,
+    weather_hourly.weather_code,
+    weather_hourly.cloud_cover,
+    weather_hourly.wind_speed_10m,
+    weather_hourly.relative_humidity_2m,
+    weather_hourly.wind_gusts_10m,
+    weather_hourly.weather_description
+from mobility_counts
+left join station_metadata
+    on mobility_counts.station_id = station_metadata.station_id
+left join weather_hourly
+    on mobility_counts.observed_at = weather_hourly.weather_at

--- a/dbt/berlin_mobility/models/marts/schema.yml
+++ b/dbt/berlin_mobility/models/marts/schema.yml
@@ -1,0 +1,66 @@
+version: 2
+
+models:
+  - name: fact_mobility_weather
+    description: Hourly station-level bike counts enriched with station metadata and Berlin weather observations.
+    columns:
+      - name: observed_at
+        description: Timestamp of the hourly bike count observation.
+        tests:
+          - not_null
+      - name: observed_local_at
+        description: Observation timestamp converted to Europe/Berlin local time.
+      - name: station_id
+        description: Bike counting station identifier.
+        tests:
+          - not_null
+      - name: bike_count
+        description: Observed bike count for the station and hour.
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              arguments:
+                min_value: 0
+                inclusive: true
+      - name: observed_date
+        description: Calendar date of the observation.
+      - name: observed_hour
+        description: Hour of day in local time.
+      - name: observed_isodow
+        description: ISO day of week, where Monday is 1 and Sunday is 7.
+      - name: is_weekend
+        description: True when the observation falls on Saturday or Sunday.
+      - name: station_description
+        description: Human-readable station description.
+      - name: station_latitude
+        description: Station latitude.
+      - name: station_longitude
+        description: Station longitude.
+      - name: station_installed_date
+        description: Date the counting station was installed.
+      - name: station_direction
+        description: Count direction described by the source metadata.
+      - name: temperature_2m
+        description: Air temperature at 2 meters.
+      - name: apparent_temperature
+        description: Apparent temperature.
+      - name: precipitation
+        description: Hourly precipitation amount.
+      - name: weather_code
+        description: Open-Meteo weather condition code.
+      - name: cloud_cover
+        description: Cloud cover percentage.
+      - name: wind_speed_10m
+        description: Wind speed at 10 meters.
+      - name: relative_humidity_2m
+        description: Relative humidity at 2 meters.
+      - name: wind_gusts_10m
+        description: Wind gust speed at 10 meters.
+      - name: weather_description
+        description: Human-readable weather condition.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - observed_at
+              - station_id


### PR DESCRIPTION
## Summary
- add a dbt marts layer materialized as views
- add fact_mobility_weather for station-hour bike counts enriched with station metadata and weather
- add dashboard-friendly Berlin-local date/time fields and dbt tests

## Verification
- git diff --check
- dbt parse
- dbt run --select fact_mobility_weather
- dbt test --select fact_mobility_weather
- sanity query against analytics.fact_mobility_weather