### PR TITLE
Configure Metabase mart metadata

### DIFF
--- a/scripts/metabase_seed.sh
+++ b/scripts/metabase_seed.sh
@@ -63,10 +63,10 @@ test -n "$SESSION"
 echo "Session created."
 
 echo "Checking whether datasource 'mobility' already exists..."
-DB_EXISTS=$(curl -sSf -H "X-Metabase-Session: $SESSION" "$METABASE_URL/api/database" \
-  | python -c 'import sys, json; payload=json.load(sys.stdin); items=payload.get("data", payload); print(any(db.get("name")=="mobility" for db in items))')
+MOBILITY_DB_ID=$(curl -sSf -H "X-Metabase-Session: $SESSION" "$METABASE_URL/api/database" \
+  | python -c 'import sys, json; payload=json.load(sys.stdin); items=payload.get("data", payload); matches=[db for db in items if db.get("name")=="mobility"]; print(matches[0]["id"] if matches else "")')
 
-if [ "$DB_EXISTS" = "True" ]; then
+if [ -n "$MOBILITY_DB_ID" ]; then
   echo "Datasource 'mobility' already exists. Skipping creation."
 else
   echo "Adding mobility datasource..."
@@ -93,6 +93,116 @@ PY
     -H "X-Metabase-Session: $SESSION" \
     -d "$DATASOURCE_PAYLOAD" >/dev/null
   echo "Datasource added."
+
+  MOBILITY_DB_ID=$(curl -sSf -H "X-Metabase-Session: $SESSION" "$METABASE_URL/api/database" \
+    | python -c 'import sys, json; payload=json.load(sys.stdin); items=payload.get("data", payload); matches=[db for db in items if db.get("name")=="mobility"]; print(matches[0]["id"] if matches else "")')
 fi
+
+test -n "$MOBILITY_DB_ID"
+
+echo "Syncing mobility datasource schema..."
+curl -sSf -X POST "$METABASE_URL/api/database/$MOBILITY_DB_ID/sync_schema" \
+  -H "Content-Type: application/json" \
+  -H "X-Metabase-Session: $SESSION" \
+  -d "{}" >/dev/null
+echo "Schema sync requested."
+
+echo "Configuring mart metadata if fact_mobility_weather exists..."
+python - "$METABASE_URL" "$SESSION" "$MOBILITY_DB_ID" <<'PY'
+import json
+import sys
+import time
+import urllib.request
+
+
+metabase_url = sys.argv[1]
+session = sys.argv[2]
+database_id = sys.argv[3]
+
+TABLE_SCHEMA = "analytics"
+TABLE_NAME = "fact_mobility_weather"
+
+FIELD_METADATA = {
+    "observed_at": {"display_name": "Observed At"},
+    "observed_local_at": {"display_name": "Observed Local At"},
+    "station_id": {"display_name": "Station ID", "semantic_type": "type/Category"},
+    "bike_count": {"display_name": "Bike Count", "semantic_type": "type/Quantity"},
+    "observed_date": {"display_name": "Observed Date"},
+    "observed_hour": {"display_name": "Observed Hour"},
+    "observed_isodow": {"display_name": "Observed ISO Day of Week"},
+    "is_weekend": {"display_name": "Is Weekend"},
+    "station_description": {"display_name": "Station Description", "semantic_type": "type/Description"},
+    "station_latitude": {"display_name": "Station Latitude", "semantic_type": "type/Latitude"},
+    "station_longitude": {"display_name": "Station Longitude", "semantic_type": "type/Longitude"},
+    "station_installed_date": {"display_name": "Station Installed Date"},
+    "station_direction": {"display_name": "Station Direction", "semantic_type": "type/Category"},
+    "temperature_2m": {"display_name": "Temperature 2m", "semantic_type": "type/Quantity"},
+    "apparent_temperature": {"display_name": "Apparent Temperature", "semantic_type": "type/Quantity"},
+    "precipitation": {"display_name": "Precipitation", "semantic_type": "type/Quantity"},
+    "weather_code": {"display_name": "Weather Code", "semantic_type": "type/Category"},
+    "cloud_cover": {"display_name": "Cloud Cover", "semantic_type": "type/Quantity"},
+    "wind_speed_10m": {"display_name": "Wind Speed 10m", "semantic_type": "type/Quantity"},
+    "relative_humidity_2m": {"display_name": "Relative Humidity 2m", "semantic_type": "type/Quantity"},
+    "wind_gusts_10m": {"display_name": "Wind Gusts 10m", "semantic_type": "type/Quantity"},
+    "weather_description": {"display_name": "Weather Description", "semantic_type": "type/Description"},
+}
+
+
+def api(path, payload=None, method=None):
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{metabase_url}{path}",
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "X-Metabase-Session": session,
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(request) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body) if body else None
+
+
+def find_table():
+    metadata = api(f"/api/database/{database_id}/metadata")
+    for table in metadata.get("tables", []):
+        if table.get("schema") == TABLE_SCHEMA and table.get("name") == TABLE_NAME:
+            return table
+    return None
+
+
+table = None
+for _ in range(15):
+    table = find_table()
+    if table:
+        break
+    time.sleep(2)
+
+if not table:
+    print("Mart analytics.fact_mobility_weather not found yet. Run dbt/Airflow and rerun this seed to apply metadata.")
+    sys.exit(0)
+
+table_id = table["id"]
+api(
+    f"/api/table/{table_id}",
+    {
+        "display_name": "Mobility Weather",
+        "description": "Hourly bike counts enriched with station metadata and Berlin weather observations.",
+    },
+    method="PUT",
+)
+
+table_metadata = api(f"/api/table/{table_id}/query_metadata")
+updated_fields = 0
+for field in table_metadata.get("fields", []):
+    field_update = FIELD_METADATA.get(field.get("name"))
+    if not field_update:
+        continue
+    api(f"/api/field/{field['id']}", field_update, method="PUT")
+    updated_fields += 1
+
+print(f"Configured metadata for analytics.fact_mobility_weather ({updated_fields} fields).")
+PY
 
 echo "Metabase setup finished."


### PR DESCRIPTION
## Summary
- request a Metabase schema sync during seeding
- configure the fact_mobility_weather mart display name and description when available
- apply dashboard-friendly field display names and semantic types

## Verification
- docker compose --env-file .env -f docker/docker-compose.yml run --rm metabase-seed
- verified Metabase table/field metadata through the API
- bash -n scripts/metabase_seed.sh
- git diff --check
- python -m compileall scripts airflow/dags
- docker compose --env-file .env.example -f docker/docker-compose.yml config
- uv lock --check
- dbt parse