### PR TITLE
Add dashboard year and weekend filters

### DIFF
--- a/dbt/berlin_mobility/models/marts/fact_mobility_weather.sql
+++ b/dbt/berlin_mobility/models/marts/fact_mobility_weather.sql
@@ -39,6 +39,8 @@ select
     mobility_counts.bike_count,
 
     cast(timezone('Europe/Berlin', mobility_counts.observed_at) as date) as observed_date,
+    extract(year from timezone('Europe/Berlin', mobility_counts.observed_at))::integer as observed_year,
+    extract(month from timezone('Europe/Berlin', mobility_counts.observed_at))::integer as observed_month,
     extract(hour from timezone('Europe/Berlin', mobility_counts.observed_at))::integer as observed_hour,
     extract(isodow from timezone('Europe/Berlin', mobility_counts.observed_at))::integer as observed_isodow,
     extract(isodow from timezone('Europe/Berlin', mobility_counts.observed_at))::integer in (6, 7) as is_weekend,

--- a/dbt/berlin_mobility/models/marts/schema.yml
+++ b/dbt/berlin_mobility/models/marts/schema.yml
@@ -24,6 +24,10 @@ models:
                 inclusive: true
       - name: observed_date
         description: Calendar date of the observation.
+      - name: observed_year
+        description: Berlin-local calendar year of the observation.
+      - name: observed_month
+        description: Berlin-local calendar month of the observation.
       - name: observed_hour
         description: Hour of day in local time.
       - name: observed_isodow

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -7,6 +7,7 @@ The seed creates:
 - collection: `Mobility Analytics`
 - dashboard: `Mobility Overview`
 - saved questions built on `analytics.fact_mobility_weather`
+- dashboard filters for year and weekend/weekday selection
 
 ---
 
@@ -44,6 +45,13 @@ The seed is intended to be idempotent. It updates the existing collection, saved
 ---
 
 ## Current cards
+
+The dashboard currently has two filters:
+
+- `Year`: maps to `observed_year`
+- `Weekend`: maps to `is_weekend`
+
+The filters are applied to all seeded cards.
 
 ### Daily Bike Counts
 

--- a/scripts/metabase_seed.sh
+++ b/scripts/metabase_seed.sh
@@ -128,6 +128,8 @@ FIELD_METADATA = {
     "station_id": {"display_name": "Station ID", "semantic_type": "type/Category"},
     "bike_count": {"display_name": "Bike Count", "semantic_type": "type/Quantity"},
     "observed_date": {"display_name": "Observed Date"},
+    "observed_year": {"display_name": "Observed Year", "semantic_type": "type/Category"},
+    "observed_month": {"display_name": "Observed Month", "semantic_type": "type/Category"},
     "observed_hour": {"display_name": "Observed Hour"},
     "observed_isodow": {"display_name": "Observed ISO Day of Week"},
     "is_weekend": {"display_name": "Is Weekend"},
@@ -160,6 +162,9 @@ CARDS = [
                 observed_date,
                 sum(bike_count) as bike_count
             from analytics.fact_mobility_weather
+            where 1 = 1
+                [[and observed_year = {{year}}]]
+                [[and is_weekend::text = {{is_weekend}}]]
             group by observed_date
             order by observed_date
         """,
@@ -177,6 +182,9 @@ CARDS = [
                 observed_hour,
                 sum(bike_count) as bike_count
             from analytics.fact_mobility_weather
+            where 1 = 1
+                [[and observed_year = {{year}}]]
+                [[and is_weekend::text = {{is_weekend}}]]
             group by observed_hour
             order by observed_hour
         """,
@@ -194,6 +202,9 @@ CARDS = [
                 coalesce(station_description, station_id) as station,
                 sum(bike_count) as bike_count
             from analytics.fact_mobility_weather
+            where 1 = 1
+                [[and observed_year = {{year}}]]
+                [[and is_weekend::text = {{is_weekend}}]]
             group by station
             order by bike_count desc
             limit 15
@@ -214,6 +225,9 @@ CARDS = [
                     max(precipitation) as precipitation,
                     sum(bike_count) as bike_count
                 from analytics.fact_mobility_weather
+                where 1 = 1
+                    [[and observed_year = {{year}}]]
+                    [[and is_weekend::text = {{is_weekend}}]]
                 group by observed_at
             ),
 
@@ -253,6 +267,40 @@ DASHCARD_LAYOUT = {
 
 LEGACY_CARD_NAMES = {
     "Bike Counts by Weather",
+}
+
+DASHBOARD_PARAMETERS = [
+    {
+        "id": "year",
+        "name": "Year",
+        "slug": "year",
+        "type": "category",
+        "sectionId": "string",
+    },
+    {
+        "id": "is_weekend",
+        "name": "Weekend",
+        "slug": "is_weekend",
+        "type": "category",
+        "sectionId": "string",
+    },
+]
+
+CARD_TEMPLATE_TAGS = {
+    "year": {
+        "id": "year",
+        "name": "year",
+        "display-name": "Year",
+        "type": "number",
+        "required": False,
+    },
+    "is_weekend": {
+        "id": "is_weekend",
+        "name": "is_weekend",
+        "display-name": "Weekend",
+        "type": "text",
+        "required": False,
+    },
 }
 
 
@@ -324,7 +372,10 @@ def card_payload(card, collection_id):
         "dataset_query": {
             "database": int(database_id),
             "type": "native",
-            "native": {"query": normalize_sql(card["query"])},
+            "native": {
+                "query": normalize_sql(card["query"]),
+                "template-tags": CARD_TEMPLATE_TAGS,
+            },
         },
         "visualization_settings": card["visualization_settings"],
     }
@@ -389,7 +440,14 @@ def dashboard_card_payload(dashcard_id, card_id, card_name):
         "id": dashcard_id,
         "card_id": card_id,
         "card": {"id": card_id},
-        "parameter_mappings": [],
+        "parameter_mappings": [
+            {
+                "parameter_id": parameter["id"],
+                "card_id": card_id,
+                "target": ["variable", ["template-tag", parameter["id"]]],
+            }
+            for parameter in DASHBOARD_PARAMETERS
+        ],
         "series": [],
         "size_x": layout["size_x"],
         "size_y": layout["size_y"],
@@ -425,6 +483,7 @@ def ensure_dashboard_cards(dashboard_id, card_ids):
             "collection_id": dashboard.get("collection_id"),
             "dashcards": dashcards,
             "tabs": dashboard.get("tabs", []),
+            "parameters": DASHBOARD_PARAMETERS,
         },
         method="PUT",
     )


### PR DESCRIPTION
## Summary
- add observed_year and observed_month to the fact mart
- seed Metabase dashboard filters for year and weekend/weekday selection
- map both filters to all seeded dashboard cards
- document the dashboard filters in the dashboard guide

## Verification
- dbt parse
- dbt run --select fact_mobility_weather
- dbt test --select fact_mobility_weather
- verified year/month fields via SQL
- metabase-seed ran successfully
- verified dashboard filter mappings and a filtered dashboard card query via the API
- bash -n scripts/metabase_seed.sh
- git diff --check
- python -m compileall scripts airflow/dags
- docker compose --env-file .env.example -f docker/docker-compose.yml config
- uv lock --check